### PR TITLE
Resolve build error (chore): Added `rimraf` glob pattern support to `build` script command in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "dev": "vite --host",
-    "build": "rimraf build/**/* && tsc && vite build && dts-bundle-generator --config ./dts-bundle-generator.config.ts && copyfiles ./package.json build",
+    "build": "rimraf --glob build/**/* && tsc && vite build && dts-bundle-generator --config ./dts-bundle-generator.config.ts && copyfiles ./package.json build",
     "test": "vitest",
     "test:coverage": "vitest --coverage",
     "lint:scripts": "eslint . --ext .ts",


### PR DESCRIPTION
## Active PR Dependancies

None.

## Premise

Since `rimraf` v4.2, glob pattern support was made opt-in. To opt-in, the `--glob` CLI option must be added. Please see `rimraf` upgrade guide: [https://github.com/isaacs/rimraf?tab=readme-ov-file#v3-to-v4](https://github.com/isaacs/rimraf?tab=readme-ov-file#v3-to-v4)

Failing to do so, will produce a error similar to the below when running `npm run-script build`:

```
❯ npm run-script build

> vite-vanilla-ts-lib-starter@0.0.4 build

Error: Illegal characters in path.
    at pathArg (file:///C:/Users/{{PC-Username}}/source/repos/vite-vanilla-ts-lib-starter/node_modules/rimraf/dist/esm/path-arg.js:38:33)
    at file:///C:/Users/{{PC-Username}}/source/repos/vite-vanilla-ts-lib-starter/node_modules/rimraf/dist/esm/index.js:17:54
    at Array.map (<anonymous>)
    at file:///C:/Users/{{PC-Username}}/source/repos/vite-vanilla-ts-lib-starter/node_modules/rimraf/dist/esm/index.js:17:42
    at main (file:///C:/Users/{{PC-Username}}/source/repos/vite-vanilla-ts-lib-starter/node_modules/rimraf/dist/esm/bin.mjs:245:15)
    at file:///C:/Users/{{PC-Username}}/source/repos/vite-vanilla-ts-lib-starter/node_modules/rimraf/dist/esm/bin.mjs:254:5
    at ModuleJob.run (node:internal/modules/esm/module_job:222:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:316:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:123:5) {
  path: 'C:\\Users\\{{PC-Username}}\\source\\repos\\vite-vanilla-ts-lib-starter\\build\\**\\*',
  code: 'EINVAL'
}
```

This change resolves the above error.

## Changes

- Added `--glob` option to the `rimraf` command for the `build` script inside the `package.json` file.